### PR TITLE
Use spawn to launch processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mxhkd"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bimap 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "mxhkd"
 description = "Modal X Hotkey Daemon"
-version     = "0.0.3"
+version     = "0.0.4"
 authors     = ["Carlos D'Agostino <m@cdagostino.io>", "Robert McMichael <none@none.com>"]
 edition     = "2018"
 build       = "build.rs"

--- a/src/xcb_util.rs
+++ b/src/xcb_util.rs
@@ -119,14 +119,9 @@ pub fn key_for(key_event: &xcb::KeyPressEvent, xmodmap: &XModMap, config: &Confi
 
 /// Runs a command
 pub fn run_command(shell: &str, cmd: &str) {
-    println!("Running command: {}", cmd);
-    match Command::new(shell).arg("-c").arg(cmd).output() {
-        Ok(out) => {
-            if !out.status.success() {
-                println!("No success whilst running '{}'.", cmd);
-                let _ = io::stdout().write_all(&out.stderr);
-            }
-        }
+    println!("Spawning command: {}", cmd);
+    match Command::new(shell).arg("-c").arg(cmd).spawn() {
+        Ok(_) => (),
         Err(e) => println!("Error running {}. Error: {:?}.", cmd, e),
     }
 }


### PR DESCRIPTION
Use `spawn` instead of `output` since its non-blocking
and preferable in case mxkhd is used to start up
long-running applications (such as Slack).

Much better process management is still required (lots 
of `<defunct>` processes are left lying around :sweat_smile:)